### PR TITLE
Dev

### DIFF
--- a/.claude/skills/yumekit/reference.md
+++ b/.claude/skills/yumekit/reference.md
@@ -1363,6 +1363,7 @@ Methods: `.show(opts)` — **single options object**: `{ message, color, duratio
 | `position` | `top` (default) \| `bottom` \| `left` \| `right` |
 | `size`     | `small` \| `medium` \| `large`                   |
 | `variant`  | `default` (bordered boxes) \| `accent` (minimal tabs; active tab shows a primary indicator border on its content-facing edge, like Material/Carbon) |
+| `overflow` | `scroll` (default; one line + prev/next arrows when the strip overflows) \| `wrap` (tabs flow onto multiple rows/columns) |
 
 Options object shape: `{"id":"tab1","label":"Tab 1","slot":"tab1","disabled":false,"leftIcon":"home","rightIcon":"arrow-right"}` — `id`, `label`, and `slot` are required; `disabled`, `leftIcon`, `rightIcon` are optional.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Delete any empty sections before publishing.
 <!-- ### Security -->
 <!-- Vulnerability patches or hardening changes -->
 
+## [0.5.2]
+
+### Added
+
+- `y-tabs` gains an `overflow` attribute: `scroll` (default) keeps tabs on a single line and shows prev/next arrow buttons when the strip overflows its container, while `wrap` lets tabs flow onto multiple rows.
+
+### Changed
+
+- `y-code` now scrolls its content within a height-constrained container — set a CSS `height` or `max-height` and the code area scrolls, where previously vertical scrolling only kicked in with `max-lines`.
+
 ## [0.5.1] - 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Delete any empty sections before publishing.
 <!-- ### Security -->
 <!-- Vulnerability patches or hardening changes -->
 
-## [0.5.2]
+## [0.5.2] - 2026-06-27
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -73,68 +73,59 @@ Then use the `<y-theme>` component to apply a theme:
 
 ## Components
 
-| Component     | Element            | Description                                              |
-| ------------- | ------------------ | ------------------------------------------------------- |
-| Animate       | `<y-animate>`      | Scroll/viewport-triggered animation wrapper             |
-| App Bar       | `<y-appbar>`       | Top or side navigation bar                              |
-| Avatar        | `<y-avatar>`       | User avatar with shape and color variants               |
-| Avatar Group  | `<y-avatar-group>` | Overlapping avatar group with overflow count            |
-| Badge         | `<y-badge>`        | Status badge or label                                   |
-| Banner        | `<y-banner>`       | Full-width inline message / alert banner                |
-| Break         | `<y-break>`        | Divider with optional centered label, icon, or slot     |
-| Breadcrumbs   | `<y-breadcrumbs>`  | Navigation breadcrumb trail with collapse support       |
-| Button        | `<y-button>`       | Button with icon, size, and style variants              |
-| Button Group  | `<y-button-group>` | Groups buttons (or inputs) into a connected toolbar     |
-| Card          | `<y-card>`         | Content card container                                  |
-| Checkbox      | `<y-checkbox>`     | Form checkbox input                                     |
-| Code          | `<y-code>`         | Code block with built-in syntax highlighting            |
-| Color         | `<y-color>`        | Color swatch / value display                            |
-| Color Picker  | `<y-colorpicker>`  | Interactive color picker                                |
-| Data Grid     | `<y-data-grid>`    | Data grid with sorting, filtering, editing, pagination  |
-| Date          | `<y-date>`         | Date input                                              |
-| DatePicker    | `<y-datepicker>`   | A date and time picker                                  |
-| Dialog        | `<y-dialog>`       | Modal dialog                                            |
-| Dock          | `<y-dock>`         | Fixed navigation dock                                   |
-| Drawer        | `<y-drawer>`       | Side drawer / sidebar                                   |
-| Droplist      | `<y-droplist>`     | Drag-and-drop reorderable list                          |
-| Gallery       | `<y-gallery>`      | Media gallery with lightbox                             |
-| Grid          | `<y-grid>`         | CSS Grid layout container                               |
-| Help          | `<y-help>`         | Guided product tour / onboarding walkthrough            |
-| Icon          | `<y-icon>`         | SVG icon display                                        |
-| Input         | `<y-input>`        | Text input field                                        |
-| Masonry       | `<y-masonry>`      | JS-positioned masonry layout                            |
-| Menu          | `<y-menu>`         | Dropdown navigation menu                                |
-| Paginator     | `<y-paginator>`    | Pagination controls                                     |
-| Panel Bar     | `<y-panelbar>`     | Accordion panel group                                   |
-| Popover       | `<y-popover>`      | Anchored floating popover                               |
-| Progress      | `<y-progress>`     | Progress bar                                            |
-| Radio         | `<y-radio>`        | Radio button input                                      |
-| Rating        | `<y-rating>`       | Star / icon rating input                                |
-| Select        | `<y-select>`       | Select / dropdown input                                 |
-| Shape         | `<y-shape>`        | Decorative CSS shape container                          |
-| Sidebar       | `<y-sidebar>`      | Collapsible app sidebar navigation                      |
-| Slider        | `<y-slider>`       | Range slider input                                      |
-| Splitter      | `<y-splitter>`     | Two-pane container with a draggable resize handle       |
-| Stack         | `<y-stack>`        | Flexbox layout container (row or column)                |
-| Stepper       | `<y-stepper>`      | Multi-step wizard with sequential flow                  |
-| Switch        | `<y-switch>`       | Toggle switch                                           |
-| Table         | `<y-table>`        | Sortable data table                                     |
-| Tabs          | `<y-tabs>`         | Tabbed interface                                        |
-| Tag           | `<y-tag>`          | Tag / chip label                                        |
-| Textarea      | `<y-textarea>`     | Multi-line text input                                   |
-| Theme         | `<y-theme>`        | Theme provider                                          |
-| Toast         | `<y-toast>`        | Notification toast                                      |
-| Tooltip       | `<y-tooltip>`      | Tooltip / popover                                       |
-| Tree          | `<y-tree>`         | Hierarchical tree view                                  |
-
-### Sub-elements
-
-These are building blocks used inside their parent component, not standalone components (and not included in the count above):
-
-| Element         | Used inside    | Description                       |
-| --------------- | -------------- | -------------------------------- |
-| `<y-panel>`     | `<y-panelbar>` | Individual accordion panel       |
-| `<y-tree-item>` | `<y-tree>`     | Individual node within a tree    |
+| Component    | Element            | Description                                            |
+| ------------ | ------------------ | ------------------------------------------------------ |
+| Animate      | `<y-animate>`      | Scroll/viewport-triggered animation wrapper            |
+| App Bar      | `<y-appbar>`       | Top or side navigation bar                             |
+| Avatar       | `<y-avatar>`       | User avatar with shape and color variants              |
+| Avatar Group | `<y-avatar-group>` | Overlapping avatar group with overflow count           |
+| Badge        | `<y-badge>`        | Status badge or label                                  |
+| Banner       | `<y-banner>`       | Full-width inline message / alert banner               |
+| Break        | `<y-break>`        | Divider with optional centered label, icon, or slot    |
+| Breadcrumbs  | `<y-breadcrumbs>`  | Navigation breadcrumb trail with collapse support      |
+| Button       | `<y-button>`       | Button with icon, size, and style variants             |
+| Button Group | `<y-button-group>` | Groups buttons (or inputs) into a connected toolbar    |
+| Card         | `<y-card>`         | Content card container                                 |
+| Checkbox     | `<y-checkbox>`     | Form checkbox input                                    |
+| Code         | `<y-code>`         | Code block with built-in syntax highlighting           |
+| Color        | `<y-color>`        | Color swatch / value display                           |
+| Color Picker | `<y-colorpicker>`  | Interactive color picker                               |
+| Data Grid    | `<y-data-grid>`    | Data grid with sorting, filtering, editing, pagination |
+| Date         | `<y-date>`         | Date input                                             |
+| DatePicker   | `<y-datepicker>`   | A date and time picker                                 |
+| Dialog       | `<y-dialog>`       | Modal dialog                                           |
+| Dock         | `<y-dock>`         | Fixed navigation dock                                  |
+| Drawer       | `<y-drawer>`       | Side drawer / sidebar                                  |
+| Droplist     | `<y-droplist>`     | Drag-and-drop reorderable list                         |
+| Gallery      | `<y-gallery>`      | Media gallery with lightbox                            |
+| Grid         | `<y-grid>`         | CSS Grid layout container                              |
+| Help         | `<y-help>`         | Guided product tour / onboarding walkthrough           |
+| Icon         | `<y-icon>`         | SVG icon display                                       |
+| Input        | `<y-input>`        | Text input field                                       |
+| Masonry      | `<y-masonry>`      | JS-positioned masonry layout                           |
+| Menu         | `<y-menu>`         | Dropdown navigation menu                               |
+| Paginator    | `<y-paginator>`    | Pagination controls                                    |
+| Panel Bar    | `<y-panelbar>`     | Accordion panel group                                  |
+| Popover      | `<y-popover>`      | Anchored floating popover                              |
+| Progress     | `<y-progress>`     | Progress bar                                           |
+| Radio        | `<y-radio>`        | Radio button input                                     |
+| Rating       | `<y-rating>`       | Star / icon rating input                               |
+| Select       | `<y-select>`       | Select / dropdown input                                |
+| Shape        | `<y-shape>`        | Decorative CSS shape container                         |
+| Sidebar      | `<y-sidebar>`      | Collapsible app sidebar navigation                     |
+| Slider       | `<y-slider>`       | Range slider input                                     |
+| Splitter     | `<y-splitter>`     | Two-pane container with a draggable resize handle      |
+| Stack        | `<y-stack>`        | Flexbox layout container (row or column)               |
+| Stepper      | `<y-stepper>`      | Multi-step wizard with sequential flow                 |
+| Switch       | `<y-switch>`       | Toggle switch                                          |
+| Table        | `<y-table>`        | Sortable data table                                    |
+| Tabs         | `<y-tabs>`         | Tabbed interface                                       |
+| Tag          | `<y-tag>`          | Tag / chip label                                       |
+| Textarea     | `<y-textarea>`     | Multi-line text input                                  |
+| Theme        | `<y-theme>`        | Theme provider                                         |
+| Toast        | `<y-toast>`        | Notification toast                                     |
+| Tooltip      | `<y-tooltip>`      | Tooltip / popover                                      |
+| Tree         | `<y-tree>`         | Hierarchical tree view                                 |
 
 ---
 

--- a/llm.txt
+++ b/llm.txt
@@ -1657,6 +1657,7 @@ Attributes:
 - `position` — `"top"` (default) | `"bottom"` | `"left"` | `"right"`
 - `size` — `"small"` | `"medium"` | `"large"`
 - `variant` — `"default"` (default, bordered boxes) | `"accent"` (minimal tabs; the active tab shows a primary-colored indicator border on its content-facing edge — bottom for `top` tabs, top for `bottom`, etc. — like Material/Carbon)
+- `overflow` — `"scroll"` (default; tabs stay on one line and prev/next arrow buttons appear when the strip overflows its container) | `"wrap"` (tabs flow onto multiple rows, or columns for `left`/`right` positions)
 
 Methods: `activateTab(id)`
 

--- a/llm.txt
+++ b/llm.txt
@@ -3,7 +3,7 @@
 A modern, framework-agnostic Web Components UI kit providing 51 production-ready custom HTML elements. Built entirely on native web standards with zero external runtime dependencies.
 
 ## Version
-0.5.2-beta.1
+0.5.2
 
 ## License
 MIT

--- a/llm.txt
+++ b/llm.txt
@@ -3,7 +3,7 @@
 A modern, framework-agnostic Web Components UI kit providing 51 production-ready custom HTML elements. Built entirely on native web standards with zero external runtime dependencies.
 
 ## Version
-0.5.1-beta.16
+0.5.2-beta.1
 
 ## License
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waggylabs/yumekit",
-    "version": "0.5.1",
+    "version": "0.5.2-beta.1",
     "description": "Modern Web Component UI Kit",
     "type": "module",
     "main": "dist/yumekit.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waggylabs/yumekit",
-    "version": "0.5.2-beta.1",
+    "version": "0.5.2",
     "description": "Modern Web Component UI Kit",
     "type": "module",
     "main": "dist/yumekit.min.js",

--- a/scripts/bundle-ai-docs.js
+++ b/scripts/bundle-ai-docs.js
@@ -1,3 +1,10 @@
+// Stages the AI-assistant docs into dist/ so they ship with the package and the
+// `init-ai` CLI can copy them into a consumer's project. dist is already in the
+// published `files` allowlist, so this avoids dot-directory publish quirks and
+// keeps the installed paths clean.
+//
+// Usage: `node scripts/bundle-ai-docs.js` (runs as part of `npm run build`)
+
 import {
     cpSync,
     existsSync,
@@ -8,46 +15,56 @@ import {
 } from "fs";
 import { join } from "path";
 
-// Stages the AI-assistant docs into dist/ so they ship with the package and the
-// `init-ai` CLI can copy them into a consumer's project. dist is already in the
-// published `files` allowlist, so this avoids dot-directory publish quirks and
-// keeps the installed paths clean.
-
-const skillSrc = ".claude/skills/yumekit";
-const llmSrc = "llm.txt";
-const outDir = "dist/ai";
-const skillOut = join(outDir, "skill");
-const repo = "https://github.com/waggylabs/yumekit/blob/main";
-
-if (!existsSync(skillSrc)) {
-    console.error(`✗ Skill source not found at ${skillSrc}`);
-    process.exit(1);
-}
-
-rmSync(outDir, { recursive: true, force: true });
-mkdirSync(outDir, { recursive: true });
-
-cpSync(skillSrc, skillOut, { recursive: true });
+const SKILL_SRC = ".claude/skills/yumekit";
+const LLM_SRC = "llm.txt";
+const OUT_DIR = "dist/ai";
+const SKILL_OUT = join(OUT_DIR, "skill");
+const REPO = "https://github.com/waggylabs/yumekit/blob/main";
 
 // The skill's one repo-relative link points at contributor-only docs that don't
-// ship and would resolve to bogus paths inside a consumer's project — rewrite it
-// to absolute GitHub URLs. Fail loudly if the source phrasing changed, so we
-// never silently ship the unreplaced contributor-only links.
-const skillMd = join(skillOut, "SKILL.md");
-const linkPattern = /When writing or modifying component source code.*$/m;
-const original = readFileSync(skillMd, "utf8");
-if (!linkPattern.test(original)) {
-    console.error(
-        `✗ ${skillMd}: expected contributor-doc link sentence not found — update the rewrite pattern in bundle-ai-docs.js.`,
-    );
-    process.exit(1);
+// ship and would resolve to bogus paths inside a consumer's project. Rewrite it
+// to absolute GitHub URLs, failing loudly if the source phrasing changed so we
+// never silently ship the unreplaced contributor-only link.
+const CONTRIBUTOR_LINK = /When writing or modifying component source code.*$/m;
+
+// Recreates OUT_DIR from scratch and copies the skill tree into it.
+function stageSkill() {
+    rmSync(OUT_DIR, { recursive: true, force: true });
+    mkdirSync(OUT_DIR, { recursive: true });
+    cpSync(SKILL_SRC, SKILL_OUT, { recursive: true });
 }
-const md = original.replace(
-    linkPattern,
-    `When contributing to YumeKit itself, follow the authoring standards in [CONTRIBUTING.md](${repo}/CONTRIBUTING.md#component-authoring-standards) and [CLAUDE.md](${repo}/CLAUDE.md).`,
-);
-writeFileSync(skillMd, md);
 
-cpSync(llmSrc, join(outDir, "llm.txt"));
+// Rewrites the contributor-only link in the bundled SKILL.md to absolute URLs.
+// Exits with an error if the expected source sentence is missing.
+function rewriteContributorLink() {
+    const skillMd = join(SKILL_OUT, "SKILL.md");
+    const original = readFileSync(skillMd, "utf8");
 
-console.log(`✔ Bundled AI docs → ${outDir} (skill + llm.txt)`);
+    if (!CONTRIBUTOR_LINK.test(original)) {
+        console.error(
+            `✗ ${skillMd}: expected contributor-doc link sentence not found — update the rewrite pattern in bundle-ai-docs.js.`,
+        );
+        process.exit(1);
+    }
+
+    const rewritten = original.replace(
+        CONTRIBUTOR_LINK,
+        `When contributing to YumeKit itself, follow the authoring standards in [CONTRIBUTING.md](${REPO}/CONTRIBUTING.md#component-authoring-standards) and [CLAUDE.md](${REPO}/CLAUDE.md).`,
+    );
+    writeFileSync(skillMd, rewritten);
+}
+
+function main() {
+    if (!existsSync(SKILL_SRC)) {
+        console.error(`✗ Skill source not found at ${SKILL_SRC}`);
+        process.exit(1);
+    }
+
+    stageSkill();
+    rewriteContributorLink();
+    cpSync(LLM_SRC, join(OUT_DIR, "llm.txt"));
+
+    console.log(`✔ Bundled AI docs → ${OUT_DIR} (skill + llm.txt)`);
+}
+
+main();

--- a/scripts/check-docs.js
+++ b/scripts/check-docs.js
@@ -1,18 +1,18 @@
-import { readdirSync, readFileSync, existsSync } from "fs";
-import { join } from "path";
-
 // Cross-checks the AI/consumer-facing API docs against each component's
 // `observedAttributes` — the source of truth for reflected attributes — and
 // reports drift:
 //   • react.d.ts (src/react.d.ts): observed attrs missing from the JSX types,
 //     and typed keys that aren't observed attributes (stale / property-only).
-//   • llm.txt: observed attrs not mentioned in the component's `### y-foo`
-//     section.
+//   • llm.txt / reference.md: observed attrs not mentioned in the component's
+//     `### y-foo` section.
 // These are coverage signals, not generators: attribute *types* and prose
 // descriptions are hand-authored and can't be derived from the source.
 //
 //   node scripts/check-docs.js           report
-//   node scripts/check-docs.js --check    exit 1 if any observed attr is undocumented
+//   node scripts/check-docs.js --check   exit 1 if any observed attr is undocumented
+
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
 
 const CHECK = process.argv.includes("--check");
 const DTS = "src/react.d.ts";
@@ -32,9 +32,6 @@ const GLOBAL_ATTRS = new Set([
     "class", "style", "slot", "children", "ref", "key",
 ]);
 
-const isGlobalAttr = (a) =>
-    GLOBAL_ATTRS.has(a) || a.startsWith("aria-") || a.startsWith("data-");
-
 // Verified real attributes a component reads (form association, or via
 // hasAttribute/getAttribute at render/interaction time) without listing in
 // observedAttributes — so declaring them in react.d.ts is correct, not stale.
@@ -48,21 +45,15 @@ const INTENTIONAL_EXTRAS = {
     "y-tree-item": ["history"],
 };
 
-const registered = collectRegistered("src/components");
-let failures = 0;
+const isGlobalAttr = (a) =>
+    GLOBAL_ATTRS.has(a) || a.startsWith("aria-") || a.startsWith("data-");
 
-failures += checkReactTypes();
-for (const doc of MARKDOWN_DOCS) failures += checkMarkdownDoc(doc);
+// ---------- react.d.ts coverage ----------
 
-console.log(`\n${registered.size} registered elements checked.`);
-if (CHECK && failures) {
-    console.error(`\n✗ ${failures} doc coverage issue(s). See above.`);
-    process.exit(1);
-}
-
-// --- react.d.ts ----------------------------------------------------------
-
-function checkReactTypes() {
+// Reports observed attributes missing from the JSX types, and typed keys that
+// are neither observed nor an intentional extra. Returns the count of
+// undocumented observed attributes (the --check failure signal).
+function checkReactTypes(registered) {
     const dts = readFileSync(DTS, "utf8");
     const report = [];
     let missing = 0;
@@ -74,11 +65,13 @@ function checkReactTypes() {
             missing += 1;
             continue;
         }
+
         const allowed = new Set(INTENTIONAL_EXTRAS[tag] || []);
         const undoc = [...observed].filter((a) => !typed.has(a) && !isGlobalAttr(a));
         const extra = [...typed].filter(
             (a) => !observed.has(a) && !isGlobalAttr(a) && !allowed.has(a),
         );
+
         if (undoc.length || extra.length) {
             const parts = [];
             if (undoc.length) parts.push(`missing in types: ${undoc.join(", ")}`);
@@ -93,28 +86,91 @@ function checkReactTypes() {
     return missing;
 }
 
-// --- markdown docs (llm.txt, reference.md) -------------------------------
+// Top-level attribute keys declared for `"<tag>": El<{ ... }>` in react.d.ts.
+// Returns null when the tag has no entry, an empty Set for a bare `El`
+// (attribute-less container), otherwise the set of declared key names.
+function reactAttrsFor(dts, tag) {
+    const key = `"${tag}":`;
+    const start = dts.indexOf(key);
+    if (start === -1) return null;
 
-function checkMarkdownDoc({ path, heading }) {
+    const decl = dts.slice(start + key.length).match(/^\s*El\s*(<|;)/);
+    if (!decl) return null;
+    if (decl[1] === ";") return new Set(); // bare El — container, no attrs
+
+    const body = braceBlockFrom(dts, start);
+    if (body === null) return null;
+
+    return topLevelKeys(body);
+}
+
+// Returns the brace-balanced block (including the outer braces) starting at the
+// first `{` at or after `from`, or null if there is none.
+function braceBlockFrom(text, from) {
+    let i = text.indexOf("{", from);
+    if (i === -1) return null;
+
+    let depth = 0;
+    let block = "";
+    for (; i < text.length; i++) {
+        const ch = text[i];
+        if (ch === "{") depth += 1;
+        if (depth >= 1) block += ch;
+        if (ch === "}") {
+            depth -= 1;
+            if (depth === 0) break;
+        }
+    }
+    return block;
+}
+
+// Extracts the top-level object keys from a `{ ... }` block by stripping nested
+// object literals and generics until only the outermost keys remain.
+function topLevelKeys(block) {
+    let flat = block.slice(1, -1);
+
+    let prev;
+    do {
+        prev = flat;
+        flat = flat.replace(/\{[^{}]*\}/g, "");
+    } while (flat !== prev);
+    do {
+        prev = flat;
+        flat = flat.replace(/<[^<>]*>/g, "");
+    } while (flat !== prev);
+
+    const keys = new Set();
+    for (const segment of flat.split(/[;\n]/)) {
+        const keyMatch = segment.match(/^\s*(?:"([^"]+)"|([A-Za-z_][\w-]*))\??\s*:/);
+        if (keyMatch) keys.add(keyMatch[1] || keyMatch[2]);
+    }
+    return keys;
+}
+
+// ---------- markdown coverage (llm.txt, reference.md) ----------
+
+// Reports observed attributes that lack any mention in their component's
+// markdown section. Returns the count of undocumented attributes.
+function checkMarkdownDoc(registered, { path, heading }) {
     const hashes = "#".repeat(heading);
     if (!existsSync(path)) {
         console.log(`\n· ${path} not found — skipped.`);
         return 0;
     }
-    const text = readFileSync(path, "utf8");
-    const sections = mdSections(text, heading);
+
+    const sections = mdSections(readFileSync(path, "utf8"), heading);
     const report = [];
     let missing = 0;
 
     for (const [tag, observed] of [...registered].sort()) {
-        const sec = sections[tag];
-        if (!sec) {
+        const section = sections[tag];
+        if (!section) {
             report.push(`✗ ${tag}: no "${hashes} ${tag}" section`);
             missing += 1;
             continue;
         }
         const undoc = [...observed].filter(
-            (a) => !isGlobalAttr(a) && !mentions(sec, a),
+            (a) => !isGlobalAttr(a) && !mentions(section, a),
         );
         if (undoc.length) {
             report.push(`~ ${tag}: undocumented: ${undoc.join(", ")}`);
@@ -140,17 +196,18 @@ function mentions(section, attr) {
     );
 }
 
+// Maps each y-* tag to the markdown body of its heading. A single heading may
+// cover several elements (e.g. "## y-panelbar + y-panel"); each gets the body.
 function mdSections(text, level) {
-    // Match headings at the given level that start with a y-* tag; a single
-    // heading may cover several elements (e.g. "## y-panelbar + y-panel").
     const re = new RegExp(`^#{${level}} (y-[a-z-].*)$`, "gm");
-    const out = {};
     const marks = [];
     let m;
     while ((m = re.exec(text))) {
         const tags = m[1].match(/y-[a-z-]+/g) || [];
         marks.push([tags, m.index]);
     }
+
+    const out = {};
     for (let i = 0; i < marks.length; i++) {
         const end = i + 1 < marks.length ? marks[i + 1][1] : text.length;
         const body = text.slice(marks[i][1], end);
@@ -159,7 +216,7 @@ function mdSections(text, level) {
     return out;
 }
 
-// --- shared --------------------------------------------------------------
+// ---------- component sources ----------
 
 // Map of tag -> Set(observedAttributes) for every registered y-* element.
 function collectRegistered(dir) {
@@ -183,50 +240,6 @@ function observedAttrsFor(src) {
     return attrs;
 }
 
-// Top-level attribute keys declared for `"<tag>": El<{ ... }>` in react.d.ts.
-function reactAttrsFor(dts, tag) {
-    const key = `"${tag}":`;
-    const start = dts.indexOf(key);
-    if (start === -1) return null;
-
-    const decl = dts.slice(start + key.length).match(/^\s*El\s*(<|;)/);
-    if (!decl) return null;
-    if (decl[1] === ";") return new Set(); // bare El — container, no attrs
-
-    let i = dts.indexOf("{", start);
-    if (i === -1) return null;
-    let depth = 0;
-    let body = "";
-    for (; i < dts.length; i++) {
-        const ch = dts[i];
-        if (ch === "{") depth += 1;
-        if (depth >= 1) body += ch;
-        if (ch === "}") {
-            depth -= 1;
-            if (depth === 0) break;
-        }
-    }
-
-    // Flatten nested object literals and generics so only top-level keys remain.
-    let flat = body.slice(1, -1);
-    let prev;
-    do {
-        prev = flat;
-        flat = flat.replace(/\{[^{}]*\}/g, "");
-    } while (flat !== prev);
-    do {
-        prev = flat;
-        flat = flat.replace(/<[^<>]*>/g, "");
-    } while (flat !== prev);
-
-    const keys = new Set();
-    for (const seg of flat.split(/[;\n]/)) {
-        const km = seg.match(/^\s*(?:"([^"]+)"|([A-Za-z_][\w-]*))\??\s*:/);
-        if (km) keys.add(km[1] || km[2]);
-    }
-    return keys;
-}
-
 function walk(dir, onFile) {
     if (!existsSync(dir)) return;
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -235,3 +248,21 @@ function walk(dir, onFile) {
         else onFile(full);
     }
 }
+
+// ---------- run ----------
+
+function main() {
+    const registered = collectRegistered("src/components");
+
+    let failures = checkReactTypes(registered);
+    for (const doc of MARKDOWN_DOCS) failures += checkMarkdownDoc(registered, doc);
+
+    console.log(`\n${registered.size} registered elements checked.`);
+
+    if (CHECK && failures) {
+        console.error(`\n✗ ${failures} doc coverage issue(s). See above.`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/scripts/copy-component-types.js
+++ b/scripts/copy-component-types.js
@@ -1,13 +1,29 @@
+// Flattens each component's generated type declaration up one level, so the
+// `./components/*` export paths in package.json resolve to types: copies
+// `dist/components/<name>/<name>.d.ts` → `dist/components/<name>.d.ts`.
+//
+// Usage: `node scripts/copy-component-types.js` (runs as part of `npm run build`)
+
 import { readdirSync, copyFileSync, existsSync } from "fs";
 import { join } from "path";
 
-const dir = "dist/components";
+const COMPONENTS_DIR = "dist/components";
 
-readdirSync(dir, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .forEach((d) => {
-        const src = join(dir, d.name, `${d.name}.d.ts`);
-        if (existsSync(src)) {
-            copyFileSync(src, join(dir, `${d.name}.d.ts`));
-        }
-    });
+// Copies one component's `<dir>/<name>/<name>.d.ts` up to `<dir>/<name>.d.ts`.
+// No-ops when the component has no generated declaration.
+function flattenComponentTypes(dir, name) {
+    const src = join(dir, name, `${name}.d.ts`);
+    if (!existsSync(src)) return;
+    copyFileSync(src, join(dir, `${name}.d.ts`));
+}
+
+function main() {
+    const entries = readdirSync(COMPONENTS_DIR, { withFileTypes: true });
+    const components = entries.filter((entry) => entry.isDirectory());
+
+    for (const component of components) {
+        flattenComponentTypes(COMPONENTS_DIR, component.name);
+    }
+}
+
+main();

--- a/scripts/install-ai-docs.js
+++ b/scripts/install-ai-docs.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+// `npx @waggylabs/yumekit init-ai` — copies YumeKit's bundled AI docs into the
+// current project so coding assistants (Claude Code and generic LLM tooling)
+// can use them. Opt-in and idempotent: existing files are skipped unless
+// --force is passed.
+
 import {
     appendFileSync,
     cpSync,
@@ -11,18 +16,8 @@ import {
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-// `npx @waggylabs/yumekit init-ai` — copies YumeKit's bundled AI docs into the
-// current project so coding assistants (Claude Code and generic LLM tooling)
-// can use them. Opt-in and idempotent: existing files are skipped unless
-// --force is passed.
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const aiDir = join(__dirname, "..", "dist", "ai");
-
-const args = process.argv.slice(2);
-const force = args.includes("--force");
-const wantsHelp = args.includes("--help") || args.includes("-h");
-const cmd = args.find((a) => !a.startsWith("-"));
+const AI_DIR = join(__dirname, "..", "dist", "ai");
 
 const HELP = `
 YumeKit AI docs installer
@@ -40,49 +35,11 @@ Options:
   --help    Show this help
 `;
 
-if (wantsHelp || cmd !== "init-ai") {
-    console.log(HELP);
-    process.exit(wantsHelp || !cmd ? 0 : 1);
-}
-
-if (!existsSync(aiDir)) {
-    console.error(
-        `✗ Bundled AI docs not found at ${aiDir}.\n  This package may not have been built with AI docs — please report it.`,
-    );
-    process.exit(1);
-}
-
-const cwd = process.cwd();
-const results = [];
-
-// 1. Claude skill ---------------------------------------------------------
-const skillDest = join(cwd, ".claude", "skills", "yumekit");
-if (existsSync(skillDest) && !force) {
-    results.push("• skip   .claude/skills/yumekit/ (exists — use --force)");
-} else {
-    // Clear the destination first so --force is a true replacement — a
-    // recursive copy alone would leave behind files removed/renamed upstream.
-    if (existsSync(skillDest)) rmSync(skillDest, { recursive: true, force: true });
-    mkdirSync(dirname(skillDest), { recursive: true });
-    cpSync(join(aiDir, "skill"), skillDest, { recursive: true });
-    results.push("✔ wrote  .claude/skills/yumekit/");
-}
-
-// 2. llm.txt --------------------------------------------------------------
-const llmDest = join(cwd, "llm.txt");
-if (existsSync(llmDest) && !force) {
-    results.push("• skip   llm.txt (exists — use --force)");
-} else {
-    cpSync(join(aiDir, "llm.txt"), llmDest);
-    results.push("✔ wrote  llm.txt");
-}
-
-// 3. AGENTS.md pointer ----------------------------------------------------
-// Delimited so --force can refresh the block in place without disturbing the
-// rest of the user's AGENTS.md.
+// Delimited so --force can refresh the AGENTS.md block in place without
+// disturbing the rest of the user's file.
 const POINTER_START = "<!-- yumekit-ai-docs -->";
 const POINTER_END = "<!-- /yumekit-ai-docs -->";
-const pointer = `${POINTER_START}
+const POINTER = `${POINTER_START}
 ## YumeKit UI components
 
 This project uses [@waggylabs/yumekit](https://www.yumekit.com) web components.
@@ -90,28 +47,92 @@ When building UI with \`y-*\` elements, consult:
 - \`.claude/skills/yumekit/\` — full component skill (Claude Code)
 - \`llm.txt\` — component API reference for any LLM/agent
 ${POINTER_END}`;
-const agentsDest = join(cwd, "AGENTS.md");
-if (!existsSync(agentsDest)) {
-    writeFileSync(agentsDest, `# AGENTS\n\n${pointer}\n`);
-    results.push("✔ wrote  AGENTS.md");
-} else {
-    const existing = readFileSync(agentsDest, "utf8");
-    const start = existing.indexOf(POINTER_START);
-    if (start === -1) {
-        appendFileSync(agentsDest, `\n${pointer}\n`);
-        results.push("✔ append AGENTS.md (pointer)");
-    } else if (!force) {
-        results.push("• skip   AGENTS.md (pointer present — use --force)");
-    } else {
-        // Replace the existing block (handles a legacy block with no end marker
-        // by replacing through end of file).
-        const endMark = existing.indexOf(POINTER_END, start);
-        const end = endMark === -1 ? existing.length : endMark + POINTER_END.length;
-        writeFileSync(agentsDest, existing.slice(0, start) + pointer + existing.slice(end));
-        results.push("✔ update AGENTS.md (pointer)");
+
+// ---------- install steps ----------
+
+// Copies the Claude skill tree into <cwd>/.claude/skills/yumekit/. With --force
+// the destination is cleared first so the copy is a true replacement (a plain
+// recursive copy would leave behind files removed/renamed upstream).
+function installSkill(cwd, force) {
+    const dest = join(cwd, ".claude", "skills", "yumekit");
+    if (existsSync(dest) && !force) {
+        return "• skip   .claude/skills/yumekit/ (exists — use --force)";
     }
+
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(join(AI_DIR, "skill"), dest, { recursive: true });
+    return "✔ wrote  .claude/skills/yumekit/";
 }
 
-console.log(`\nYumeKit AI docs → ${cwd}\n`);
-console.log(results.map((r) => `  ${r}`).join("\n"));
-console.log("");
+// Copies llm.txt into the project root.
+function installLlm(cwd, force) {
+    const dest = join(cwd, "llm.txt");
+    if (existsSync(dest) && !force) {
+        return "• skip   llm.txt (exists — use --force)";
+    }
+
+    cpSync(join(AI_DIR, "llm.txt"), dest);
+    return "✔ wrote  llm.txt";
+}
+
+// Writes the pointer block into AGENTS.md: creates the file if absent, appends
+// the block if the file exists without it, or (with --force) replaces an
+// existing block in place. A legacy block with no end marker is replaced
+// through end of file.
+function installAgentsPointer(cwd, force) {
+    const dest = join(cwd, "AGENTS.md");
+    if (!existsSync(dest)) {
+        writeFileSync(dest, `# AGENTS\n\n${POINTER}\n`);
+        return "✔ wrote  AGENTS.md";
+    }
+
+    const existing = readFileSync(dest, "utf8");
+    const start = existing.indexOf(POINTER_START);
+    if (start === -1) {
+        appendFileSync(dest, `\n${POINTER}\n`);
+        return "✔ append AGENTS.md (pointer)";
+    }
+    if (!force) {
+        return "• skip   AGENTS.md (pointer present — use --force)";
+    }
+
+    const endMark = existing.indexOf(POINTER_END, start);
+    const end = endMark === -1 ? existing.length : endMark + POINTER_END.length;
+    writeFileSync(dest, existing.slice(0, start) + POINTER + existing.slice(end));
+    return "✔ update AGENTS.md (pointer)";
+}
+
+// ---------- run ----------
+
+function main() {
+    const args = process.argv.slice(2);
+    const force = args.includes("--force");
+    const wantsHelp = args.includes("--help") || args.includes("-h");
+    const cmd = args.find((a) => !a.startsWith("-"));
+
+    if (wantsHelp || cmd !== "init-ai") {
+        console.log(HELP);
+        process.exit(wantsHelp || !cmd ? 0 : 1);
+    }
+
+    if (!existsSync(AI_DIR)) {
+        console.error(
+            `✗ Bundled AI docs not found at ${AI_DIR}.\n  This package may not have been built with AI docs — please report it.`,
+        );
+        process.exit(1);
+    }
+
+    const cwd = process.cwd();
+    const results = [
+        installSkill(cwd, force),
+        installLlm(cwd, force),
+        installAgentsPointer(cwd, force),
+    ];
+
+    console.log(`\nYumeKit AI docs → ${cwd}\n`);
+    console.log(results.map((r) => `  ${r}`).join("\n"));
+    console.log("");
+}
+
+main();

--- a/scripts/sync-llm-docs.js
+++ b/scripts/sync-llm-docs.js
@@ -1,6 +1,3 @@
-import { readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-
 // Keeps the mechanically-derivable numbers in the AI docs (llm.txt + the
 // Claude skill) in sync with the source of truth: package version, the count of
 // registered `y-*` custom elements, and the number of built-in themes. The
@@ -11,6 +8,9 @@ import { join } from "path";
 //   node scripts/sync-llm-docs.js          rewrite the docs in place
 //   node scripts/sync-llm-docs.js --check  report drift, exit 1 if any (CI)
 
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
 const CHECK = process.argv.includes("--check");
 
 // Nested-only sub-elements: registered custom elements that only exist as
@@ -18,106 +18,15 @@ const CHECK = process.argv.includes("--check");
 // standalone). They are excluded from the headline component count.
 const SUBELEMENTS = new Set(["y-panel", "y-tree-item"]);
 
-const version = JSON.parse(readFileSync("package.json", "utf8")).version;
-const componentCount = countCustomElements("src/components");
-const themeCount = readdirSync("tokens/themes").filter((f) =>
-    f.endsWith(".json"),
-).length;
+// ---------- Source-of-truth numbers ----------
 
-// Each target: a file, and the substitutions to apply. `find` must match
-// exactly once — if it doesn't, the prose was restructured and we surface it
-// rather than silently doing nothing.
-const targets = [
-    {
-        file: "llm.txt",
-        subs: [
-            {
-                find: /(## Version\r?\n)[^\r\n]+/,
-                replace: `$1${version}`,
-                label: "version",
-            },
-            {
-                find: /(providing )\d+( production-ready custom HTML elements)/,
-                replace: `$1${componentCount}$2`,
-                label: "component count",
-            },
-            {
-                find: /(- )\d+( built-in themes)/,
-                replace: `$1${themeCount}$2`,
-                label: "theme count",
-            },
-            {
-                find: /(\()\d+( themes total\))/,
-                replace: `$1${themeCount}$2`,
-                label: "theme count (total)",
-            },
-        ],
-    },
-    {
-        file: ".claude/skills/yumekit/SKILL.md",
-        subs: [
-            {
-                find: /(with )\d+( custom `y-\*` elements)/,
-                replace: `$1${componentCount}$2`,
-                label: "component count",
-            },
-        ],
-    },
-];
-
-// Phase 1 — validate every anchor and compute the new text, without writing.
-// A missing anchor means the prose was restructured; bail before touching files.
-const missing = [];
-const stale = [];
-const pending = [];
-
-for (const { file, subs } of targets) {
-    const original = readFileSync(file, "utf8");
-    let text = original;
-    for (const { find, replace, label } of subs) {
-        if (!find.test(text)) {
-            missing.push(`${file}: could not find anchor for "${label}"`);
-            continue;
-        }
-        const next = text.replace(find, replace);
-        if (next !== text) {
-            stale.push(`${file}: ${label}`);
-            text = next;
-        }
-    }
-    if (text !== original) pending.push({ file, text });
-}
-
-if (missing.length) {
-    console.error("\n✗ Anchor(s) not found — the docs may have been restructured:");
-    missing.forEach((m) => console.error(`  ${m}`));
-    process.exit(1);
-}
-
-// Phase 2 — write (or, in --check, just report).
-if (!CHECK) {
-    pending.forEach(({ file, text }) => writeFileSync(file, text));
-}
-stale.forEach((s) => console.log(`  ${CHECK ? "✗" : "~"} ${s}`));
-
-console.log(
-    `\nSources: v${version}, ${componentCount} components, ${themeCount} themes`,
-);
-
-if (CHECK) {
-    if (stale.length) {
-        console.error(
-            `\n✗ AI docs are out of sync (${stale.length}). Run \`npm run sync:docs\`.`,
-        );
-        process.exit(1);
-    }
-    console.log("✔ AI docs are in sync.");
-} else {
-    console.log(
-        stale.length
-            ? `✔ Synced AI docs (${stale.length} updated).`
-            : "✔ AI docs already in sync.",
-    );
+function readSources() {
+    const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+    const componentCount = countCustomElements("src/components");
+    const themeCount = readdirSync("tokens/themes").filter((f) =>
+        f.endsWith(".json"),
+    ).length;
+    return { version, componentCount, themeCount };
 }
 
 // Recursively count unique `customElements.define("y-...")` registrations,
@@ -142,3 +51,121 @@ function walk(dir, onFile) {
         else onFile(full);
     }
 }
+
+// ---------- Substitution targets ----------
+
+// Each target: a file, and the substitutions to apply. `find` must match
+// exactly once — if it doesn't, the prose was restructured and we surface it
+// rather than silently doing nothing.
+function buildTargets({ version, componentCount, themeCount }) {
+    return [
+        {
+            file: "llm.txt",
+            subs: [
+                {
+                    find: /(## Version\r?\n)[^\r\n]+/,
+                    replace: `$1${version}`,
+                    label: "version",
+                },
+                {
+                    find: /(providing )\d+( production-ready custom HTML elements)/,
+                    replace: `$1${componentCount}$2`,
+                    label: "component count",
+                },
+                {
+                    find: /(- )\d+( built-in themes)/,
+                    replace: `$1${themeCount}$2`,
+                    label: "theme count",
+                },
+                {
+                    find: /(\()\d+( themes total\))/,
+                    replace: `$1${themeCount}$2`,
+                    label: "theme count (total)",
+                },
+            ],
+        },
+        {
+            file: ".claude/skills/yumekit/SKILL.md",
+            subs: [
+                {
+                    find: /(with )\d+( custom `y-\*` elements)/,
+                    replace: `$1${componentCount}$2`,
+                    label: "component count",
+                },
+            ],
+        },
+    ];
+}
+
+// ---------- Drift planning ----------
+
+// Validate every anchor and compute the new text without writing. A missing
+// anchor means the prose was restructured; the caller bails before any write.
+function planEdits(targets) {
+    const missing = [];
+    const stale = [];
+    const pending = [];
+
+    for (const { file, subs } of targets) {
+        const original = readFileSync(file, "utf8");
+        let text = original;
+
+        for (const { find, replace, label } of subs) {
+            if (!find.test(text)) {
+                missing.push(`${file}: could not find anchor for "${label}"`);
+                continue;
+            }
+            const next = text.replace(find, replace);
+            if (next !== text) {
+                stale.push(`${file}: ${label}`);
+                text = next;
+            }
+        }
+
+        if (text !== original) pending.push({ file, text });
+    }
+
+    return { missing, stale, pending };
+}
+
+// ---------- Run ----------
+
+function main() {
+    const sources = readSources();
+    const { missing, stale, pending } = planEdits(buildTargets(sources));
+
+    if (missing.length) {
+        console.error("\n✗ Anchor(s) not found — the docs may have been restructured:");
+        missing.forEach((m) => console.error(`  ${m}`));
+        process.exit(1);
+    }
+
+    if (!CHECK) {
+        pending.forEach(({ file, text }) => writeFileSync(file, text));
+    }
+    stale.forEach((s) => console.log(`  ${CHECK ? "✗" : "~"} ${s}`));
+
+    const { version, componentCount, themeCount } = sources;
+    console.log(
+        `\nSources: v${version}, ${componentCount} components, ${themeCount} themes`,
+    );
+
+    if (CHECK) {
+        if (stale.length) {
+            console.error(
+                `\n✗ AI docs are out of sync (${stale.length}). Run \`npm run sync:docs\`.`,
+            );
+            process.exit(1);
+        }
+        console.log("✔ AI docs are in sync.");
+        return;
+    }
+
+    console.log(
+        stale.length
+            ? `✔ Synced AI docs (${stale.length} updated).`
+            : "✔ AI docs already in sync.",
+    );
+}
+
+main();

--- a/src/components/y-code/y-code.js
+++ b/src/components/y-code/y-code.js
@@ -324,7 +324,8 @@ export class YumeCode extends HTMLElement {
     _buildStyles() {
         return `
             :host {
-                display: block;
+                display: flex;
+                flex-direction: column;
                 font-family: var(--component-code-font-family, var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace));
                 color: var(--component-code-text-color, var(--base-content--, #1a1a1a));
                 background: var(--component-code-bg-color, var(--base-background-component, #f6f8fa));
@@ -374,13 +375,19 @@ export class YumeCode extends HTMLElement {
             .pre-wrap {
                 position: relative;
                 overflow: hidden;
+                display: flex;
+                flex-direction: column;
+                flex: 1 1 auto;
+                min-height: 0;
             }
 
             pre.code {
                 margin: 0;
                 padding: var(--spacing-small, 8px) 0;
+                flex: 1 1 auto;
+                min-height: 0;
                 overflow-x: ${this.wrap ? "hidden" : "auto"};
-                overflow-y: ${this.maxLines ? "auto" : "visible"};
+                overflow-y: auto;
                 font-size: var(--component-code-font-size, 0.9em);
                 line-height: var(--component-code-line-height, 1.55);
                 tab-size: 4;

--- a/src/components/y-code/y-code.stories.js
+++ b/src/components/y-code/y-code.stories.js
@@ -12,6 +12,11 @@ const SAMPLE_LONG = Array.from(
     (_, i) => `console.log("line ${i + 1}");`,
 ).join("\n");
 
+const SAMPLE_VERY_LONG = Array.from(
+    { length: 60 },
+    (_, i) => `console.log("processing item ${i + 1} of 60");`,
+).join("\n");
+
 const SAMPLE_HIGHLIGHTED_HTML = `<span class="token keyword">const</span> <span class="token function">add</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token variable">a</span><span class="token punctuation">,</span> <span class="token variable">b</span><span class="token punctuation">)</span> <span class="token operator">=&gt;</span> <span class="token variable">a</span> <span class="token operator">+</span> <span class="token variable">b</span><span class="token punctuation">;</span>
 <span class="token comment">// usage</span>
 <span class="token function">add</span><span class="token punctuation">(</span><span class="token number">1</span><span class="token punctuation">,</span> <span class="token number">2</span><span class="token punctuation">)</span><span class="token punctuation">;</span>`;
@@ -70,6 +75,19 @@ export const Collapsed = {
     args: { "max-lines": 6, "line-numbers": true },
     render: () =>
         `<y-code max-lines="6" line-numbers language="javascript">${SAMPLE_LONG}</y-code>`,
+};
+
+export const ScrollableHeight = {
+    name: "Height limited (scrolling)",
+    parameters: {
+        docs: {
+            description: {
+                story: "A CSS `max-height` (or `height`) on the element caps its size and scrolls the code area — no `max-lines` needed.",
+            },
+        },
+    },
+    render: () =>
+        `<y-code line-numbers language="javascript" filename="long.js" style="max-height:220px">${SAMPLE_VERY_LONG}</y-code>`,
 };
 
 export const PreHighlighted = {

--- a/src/components/y-code/y-code.test.js
+++ b/src/components/y-code/y-code.test.js
@@ -286,6 +286,26 @@ describe("YumeCode", () => {
         ).to.include("Show less");
     });
 
+    it("scrolls its content within a height-constrained container", async () => {
+        const source = Array.from(
+            { length: 40 },
+            (_, i) => `line ${i + 1}`,
+        ).join("\n");
+        const el = await fixture(
+            `<y-code style="max-height:120px">${source}</y-code>`,
+        );
+        await nextFrame();
+
+        const pre = el.shadowRoot.querySelector("pre.code");
+        // The element is capped well below its natural content height, and the
+        // code area scrolls rather than overflowing the box.
+        expect(el.getBoundingClientRect().height).to.be.lessThan(
+            pre.scrollHeight,
+        );
+        expect(pre.scrollHeight).to.be.greaterThan(pre.clientHeight);
+        expect(getComputedStyle(pre).overflowY).to.equal("auto");
+    });
+
     // ── Highlighted slot sanitization ──────────────────────────────────
 
     it("renders sanitized span structure from the highlighted slot", async () => {

--- a/src/components/y-tabs/y-tabs.js
+++ b/src/components/y-tabs/y-tabs.js
@@ -3,7 +3,7 @@ import { createElement as _el } from "../../modules/helpers.js";
 
 export class YumeTabs extends HTMLElement {
     static get observedAttributes() {
-        return ["options", "size", "position", "variant"];
+        return ["options", "size", "position", "variant", "overflow"];
     }
 
     // -------------------------------------------------------------------------
@@ -15,13 +15,21 @@ export class YumeTabs extends HTMLElement {
         this.attachShadow({ mode: "open" });
         this._activeTab = "";
         this._warnedSlots = new Set();
+        this._resizeObserver = null;
+        this._onTablistScroll = this._onTablistScroll.bind(this);
     }
 
     connectedCallback() {
         if (!this.hasAttribute("size")) this.setAttribute("size", "medium");
         if (!this.hasAttribute("position"))
             this.setAttribute("position", "top");
+        if (!this.hasAttribute("overflow"))
+            this.setAttribute("overflow", "scroll");
         this.render();
+    }
+
+    disconnectedCallback() {
+        this._teardownScroll();
     }
 
     attributeChangedCallback(name, oldVal, newVal) {
@@ -47,6 +55,19 @@ export class YumeTabs extends HTMLElement {
         else if (typeof val === "string") this.setAttribute("options", val);
         else this.setAttribute("options", JSON.stringify(val));
         this.render();
+    }
+
+    /**
+     * @type {"scroll"|"wrap"} How a tab strip wider (or taller) than its
+     * container behaves. `"scroll"` keeps tabs on a single line and reveals
+     * prev/next arrow buttons when the strip overflows; `"wrap"` lets tabs flow
+     * onto multiple rows (or columns, for left/right positions).
+     */
+    get overflow() {
+        return this.getAttribute("overflow") === "wrap" ? "wrap" : "scroll";
+    }
+    set overflow(val) {
+        this.setAttribute("overflow", val === "wrap" ? "wrap" : "scroll");
     }
 
     /** @type {"top"|"bottom"|"left"|"right"} Which edge the tab strip is placed on. */
@@ -107,6 +128,7 @@ export class YumeTabs extends HTMLElement {
 
         const activeDef = tabs.find((t) => t.id === this._activeTab);
 
+        this._teardownScroll();
         this.shadowRoot.innerHTML = "";
 
         const style = document.createElement("style");
@@ -119,11 +141,12 @@ export class YumeTabs extends HTMLElement {
             part: "tablist",
         });
         tabs.forEach((tab) => tablist.appendChild(this._createTabButton(tab)));
-        this.shadowRoot.appendChild(tablist);
 
+        this.shadowRoot.appendChild(this._buildTabStrip(tablist));
         this.shadowRoot.appendChild(this._createPanel(activeDef?.slot || ""));
 
         this._setupEvents();
+        this._setupScroll();
     }
 
     // -------------------------------------------------------------------------
@@ -146,6 +169,47 @@ export class YumeTabs extends HTMLElement {
         }
 
         parent.appendChild(_el("slot", { name: slotName, class: "icon-slot" }));
+    }
+
+    _buildScrollButton(direction) {
+        const vertical = this.position === "left" || this.position === "right";
+        const icon =
+            direction === "prev"
+                ? vertical
+                    ? "chevron-up"
+                    : "chevron-left"
+                : vertical
+                  ? "chevron-down"
+                  : "chevron-right";
+        const btn = _el(
+            "button",
+            {
+                type: "button",
+                class: `scroll-btn scroll-${direction}`,
+                part: `scroll-button scroll-${direction}`,
+                "aria-label":
+                    direction === "prev"
+                        ? "Scroll tabs backward"
+                        : "Scroll tabs forward",
+                tabindex: "-1",
+                hidden: "",
+            },
+            [_el("y-icon", { name: icon, size: this.size, "aria-hidden": "true" })],
+        );
+        btn.addEventListener("click", () => this._scrollTabs(direction));
+        return btn;
+    }
+
+    _buildTabStrip(tablist) {
+        const strip = _el("div", { class: "tabstrip", part: "tabstrip" });
+        if (this.overflow === "scroll") {
+            strip.appendChild(this._buildScrollButton("prev"));
+            strip.appendChild(tablist);
+            strip.appendChild(this._buildScrollButton("next"));
+        } else {
+            strip.appendChild(tablist);
+        }
+        return strip;
     }
 
     _createIcon(name) {
@@ -228,16 +292,63 @@ export class YumeTabs extends HTMLElement {
             :host([position="left"]) { flex-direction: row; }
             :host([position="right"]) { flex-direction: row-reverse; }
 
+            .tabstrip {
+                display: flex;
+                position: relative;
+                z-index: 1;
+                min-width: 0;
+                min-height: 0;
+            }
+            :host([position="left"])  .tabstrip,
+            :host([position="right"]) .tabstrip { flex-direction: column; }
+            :host([position="top"])    .tabstrip { margin-bottom: -1px; }
+            :host([position="bottom"]) .tabstrip { margin-top: -1px; }
+            :host([position="left"])   .tabstrip { margin-right: -1px; }
+            :host([position="right"])  .tabstrip { margin-left: -1px; }
+
             .tablist {
                 display: flex;
                 gap: 0;
                 position: relative;
-                z-index: 1;
+                min-width: 0;
+                min-height: 0;
             }
-            :host([position="top"])    .tablist { margin-bottom: -1px; margin-top: 0; }
-            :host([position="bottom"]) .tablist { margin-top: -1px; margin-bottom: 0; }
-            :host([position="left"])   .tablist { flex-direction: column; margin-right: -1px; margin-left: 0; }
-            :host([position="right"])  .tablist { flex-direction: column; margin-left: -1px; margin-right: 0; }
+            :host([position="left"])  .tablist,
+            :host([position="right"]) .tablist { flex-direction: column; }
+
+            /* Scroll mode: tabs stay on one line; arrow buttons drive scrolling,
+               so the native scrollbar is hidden. */
+            :host([overflow="scroll"]) .tablist {
+                flex: 1 1 auto;
+                overflow: auto;
+                scrollbar-width: none;
+                -ms-overflow-style: none;
+            }
+            :host([overflow="scroll"]) .tablist::-webkit-scrollbar { display: none; }
+
+            /* Wrap mode: tabs flow onto multiple rows (or columns). */
+            :host([overflow="wrap"]) .tablist { flex-wrap: wrap; }
+
+            .scroll-btn {
+                flex: 0 0 auto;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0 4px;
+                background: var(--component-tabs-inactive-background, var(--component-tabs-border-color));
+                color: var(--component-tabs-color);
+                border: 1px solid var(--component-tabs-border-color);
+                border-width: var(--component-tabs-border-width, var(--component-tab-border-width, 1px));
+                cursor: pointer;
+                font-family: inherit;
+            }
+            .scroll-btn[hidden] { display: none; }
+            .scroll-btn:hover { background: var(--component-tabs-background); }
+            .scroll-btn:focus-visible {
+                outline: 2px solid var(--component-tabs-accent);
+                outline-offset: -1px;
+            }
+            :host([variant="accent"]) .scroll-btn { background: transparent; border: none; }
 
             :host([position="top"])    .tablist button { border-bottom: none; }
             :host([position="bottom"]) .tablist button { border-top: none; }
@@ -353,6 +464,10 @@ export class YumeTabs extends HTMLElement {
         }
     }
 
+    _onTablistScroll() {
+        this._updateScrollButtons();
+    }
+
     _resolveActiveTab(tabs) {
         const currentInvalid =
             !this._activeTab ||
@@ -362,8 +477,26 @@ export class YumeTabs extends HTMLElement {
         }
     }
 
+    _scrollTabs(direction) {
+        const tablist = this.shadowRoot.querySelector(".tablist");
+        if (!tablist) return;
+
+        const vertical = this.position === "left" || this.position === "right";
+        const amount =
+            (vertical ? tablist.clientHeight : tablist.clientWidth) * 0.75;
+        const delta = direction === "prev" ? -amount : amount;
+
+        tablist.scrollBy(
+            vertical
+                ? { top: delta, behavior: "smooth" }
+                : { left: delta, behavior: "smooth" },
+        );
+    }
+
     _setupEvents() {
-        const buttons = Array.from(this.shadowRoot.querySelectorAll("button"));
+        const buttons = Array.from(
+            this.shadowRoot.querySelectorAll(".tablist button"),
+        );
         buttons.forEach((button) => {
             if (button.disabled) return;
             button.addEventListener("click", () =>
@@ -373,6 +506,58 @@ export class YumeTabs extends HTMLElement {
                 this._handleTabKeydown(e, buttons),
             );
         });
+    }
+
+    _setupScroll() {
+        if (this.overflow !== "scroll") return;
+
+        const tablist = this.shadowRoot.querySelector(".tablist");
+        if (!tablist) return;
+
+        tablist.addEventListener("scroll", this._onTablistScroll, {
+            passive: true,
+        });
+        if (typeof ResizeObserver !== "undefined") {
+            this._resizeObserver = new ResizeObserver(() =>
+                this._updateScrollButtons(),
+            );
+            this._resizeObserver.observe(tablist);
+            this._resizeObserver.observe(this);
+        }
+
+        this._updateScrollButtons();
+    }
+
+    _teardownScroll() {
+        this._resizeObserver?.disconnect();
+        this._resizeObserver = null;
+        const tablist = this.shadowRoot?.querySelector(".tablist");
+        tablist?.removeEventListener("scroll", this._onTablistScroll);
+    }
+
+    _updateScrollButtons() {
+        const tablist = this.shadowRoot.querySelector(".tablist");
+        const prev = this.shadowRoot.querySelector(".scroll-prev");
+        const next = this.shadowRoot.querySelector(".scroll-next");
+        if (!tablist || !prev || !next) return;
+
+        const vertical = this.position === "left" || this.position === "right";
+        const scrollSize = vertical
+            ? tablist.scrollHeight
+            : tablist.scrollWidth;
+        const clientSize = vertical
+            ? tablist.clientHeight
+            : tablist.clientWidth;
+        const scrollPos = vertical ? tablist.scrollTop : tablist.scrollLeft;
+
+        if (scrollSize - clientSize <= 1) {
+            prev.hidden = true;
+            next.hidden = true;
+            return;
+        }
+
+        prev.hidden = scrollPos <= 1;
+        next.hidden = scrollPos >= scrollSize - clientSize - 1;
     }
 }
 

--- a/src/components/y-tabs/y-tabs.stories.js
+++ b/src/components/y-tabs/y-tabs.stories.js
@@ -36,15 +36,23 @@ export default {
                 "Visual style: 'default' (bordered boxes) or 'accent' (minimal tabs with a primary indicator on the active tab's content-facing edge).",
             table: { defaultValue: { summary: "default" } },
         },
+        overflow: {
+            control: "select",
+            options: ["scroll", "wrap"],
+            description:
+                "How a tab strip wider than its container behaves: 'scroll' keeps one line and shows prev/next arrows when it overflows; 'wrap' flows tabs onto multiple rows.",
+            table: { defaultValue: { summary: "scroll" } },
+        },
     },
     args: {
         options: defaultOptions,
         size: "medium",
         position: "top",
         variant: "default",
+        overflow: "scroll",
     },
-    render: ({ options, size, position, variant }) => `
-        <y-tabs options='${options}' size="${size}" position="${position}" variant="${variant}" style="width:400px">
+    render: ({ options, size, position, variant, overflow }) => `
+        <y-tabs options='${options}' size="${size}" position="${position}" variant="${variant}" overflow="${overflow}" style="width:400px">
             <div slot="tab1"><p>Overview content goes here.</p></div>
             <div slot="tab2"><p>Details content goes here.</p></div>
             <div slot="tab3"><p>Settings content goes here.</p></div>
@@ -163,6 +171,46 @@ export const WithIcons = {
             <div slot="settings"><p>Settings content.</p></div>
         </y-tabs>
     `,
+};
+
+export const ManyTabs = {
+    name: "Many tabs (overflow)",
+    render: () => {
+        const options = Array.from({ length: 20 }, (_, i) => ({
+            id: `tab${i + 1}`,
+            label: `Section ${i + 1}`,
+            slot: `tab${i + 1}`,
+        }));
+        const panels = options
+            .map(
+                (o) =>
+                    `<div slot="${o.slot}"><p>${o.label} content goes here.</p></div>`,
+            )
+            .join("");
+        const json = JSON.stringify(options);
+        return `
+        <div style="display:flex;flex-direction:column;gap:32px">
+            <div>
+                <p style="margin:0 0 8px;font:0.85em sans-serif;opacity:0.7">overflow="scroll" (default) — arrows appear at the edges</p>
+                <y-tabs options='${json}' overflow="scroll" style="width:400px">
+                    ${panels}
+                </y-tabs>
+            </div>
+            <div>
+                <p style="margin:0 0 8px;font:0.85em sans-serif;opacity:0.7">overflow="wrap" — tabs flow onto multiple rows</p>
+                <y-tabs options='${json}' overflow="wrap" style="width:400px">
+                    ${panels}
+                </y-tabs>
+            </div>
+            <div>
+                <p style="margin:0 0 8px;font:0.85em sans-serif;opacity:0.7">Vertical scroll (position="left")</p>
+                <y-tabs options='${json}' overflow="scroll" position="left" style="width:400px;height:240px">
+                    ${panels}
+                </y-tabs>
+            </div>
+        </div>
+    `;
+    },
 };
 
 export const WithTabContentSlot = {

--- a/src/components/y-tabs/y-tabs.test.js
+++ b/src/components/y-tabs/y-tabs.test.js
@@ -21,7 +21,7 @@ describe("YumeTabs", () => {
             </y-tabs>
         `);
 
-        const tabs = el.shadowRoot.querySelectorAll("button");
+        const tabs = el.shadowRoot.querySelectorAll('[role="tab"]');
         expect(tabs.length).to.equal(3);
         expect(el.getAttribute("size")).to.equal("medium");
         expect(el.getAttribute("position")).to.equal("top");
@@ -39,7 +39,8 @@ describe("YumeTabs", () => {
             </y-tabs>
         `);
 
-        const [btn1, btn2, btn3] = el.shadowRoot.querySelectorAll("button");
+        const [btn1, btn2, btn3] =
+            el.shadowRoot.querySelectorAll('[role="tab"]');
         // btn2 disabled
         expect(btn2.disabled).to.be.true;
 
@@ -107,11 +108,13 @@ describe("YumeTabs", () => {
                 <div slot="one-slot">First</div>
             </y-tabs>
         `);
-        expect(el.shadowRoot.querySelectorAll("button").length).to.equal(3);
+        expect(el.shadowRoot.querySelectorAll('[role="tab"]').length).to.equal(
+            3,
+        );
 
         el.options = [{ id: "alpha", label: "Alpha", slot: "alpha-slot" }];
 
-        const buttons = el.shadowRoot.querySelectorAll("button");
+        const buttons = el.shadowRoot.querySelectorAll('[role="tab"]');
         expect(buttons.length).to.equal(1);
         expect(buttons[0].dataset.id).to.equal("alpha");
     });
@@ -121,7 +124,7 @@ describe("YumeTabs", () => {
         const json = '[{"id":"alpha","label":"Alpha","slot":"alpha-slot"}]';
         el.options = json;
         expect(el.getAttribute("options")).to.equal(json);
-        const buttons = el.shadowRoot.querySelectorAll("button");
+        const buttons = el.shadowRoot.querySelectorAll('[role="tab"]');
         expect(buttons.length).to.equal(1);
         expect(buttons[0].dataset.id).to.equal("alpha");
     });
@@ -317,7 +320,7 @@ describe("YumeTabs", () => {
                 <div slot="three-slot">Third</div>
             </y-tabs>
         `);
-        const buttons = el.shadowRoot.querySelectorAll("button");
+        const buttons = el.shadowRoot.querySelectorAll('[role="tab"]');
         buttons.forEach((btn, i) => {
             expect(btn.getAttribute("aria-label")).to.equal(options[i].label);
         });
@@ -472,6 +475,60 @@ describe("YumeTabs", () => {
         const btn1 = el.shadowRoot.querySelector('button[data-id="one"]');
         expect(btn1.querySelector('slot[name="right-icon-one"]')).to.exist;
         expect(warn.calledWith(sinon.match(/right-icon-one.*deprecated/))).to.be.true;
+    });
+
+    it("defaults overflow to scroll and renders hidden scroll buttons", async () => {
+        const el = await fixture(html`
+            <y-tabs options="${JSON.stringify(options)}">
+                <div slot="one-slot">First</div>
+                <div slot="two-slot">Second</div>
+                <div slot="three-slot">Third</div>
+            </y-tabs>
+        `);
+        expect(el.overflow).to.equal("scroll");
+        const prev = el.shadowRoot.querySelector(".scroll-prev");
+        const next = el.shadowRoot.querySelector(".scroll-next");
+        expect(prev).to.exist;
+        expect(next).to.exist;
+        // Not overflowing, so both arrows stay hidden.
+        expect(prev.hidden).to.be.true;
+        expect(next.hidden).to.be.true;
+    });
+
+    it("overflow=wrap renders no scroll buttons and wraps the strip", async () => {
+        const el = await fixture(html`
+            <y-tabs overflow="wrap" options="${JSON.stringify(options)}"></y-tabs>
+        `);
+        expect(el.shadowRoot.querySelector(".scroll-btn")).to.not.exist;
+        const css = el.shadowRoot.querySelector("style").textContent;
+        expect(css).to.include("flex-wrap: wrap");
+    });
+
+    it("overflow setter normalises invalid values to scroll", async () => {
+        const el = await fixture(html`
+            <y-tabs options="${JSON.stringify(options)}"></y-tabs>
+        `);
+        el.overflow = "bogus";
+        expect(el.getAttribute("overflow")).to.equal("scroll");
+        el.overflow = "wrap";
+        expect(el.getAttribute("overflow")).to.equal("wrap");
+    });
+
+    it("reveals the next scroll button when the strip overflows", async () => {
+        const many = Array.from({ length: 12 }, (_, i) => ({
+            id: `t${i}`,
+            label: `Tab number ${i}`,
+            slot: `s${i}`,
+        }));
+        const el = await fixture(html`
+            <y-tabs
+                style="width:160px"
+                options="${JSON.stringify(many)}"
+            ></y-tabs>
+        `);
+        el._updateScrollButtons();
+        expect(el.shadowRoot.querySelector(".scroll-prev").hidden).to.be.true;
+        expect(el.shadowRoot.querySelector(".scroll-next").hidden).to.be.false;
     });
 
     it("deprecated right-icon slot warning is emitted only once across re-renders", async () => {

--- a/src/react.d.ts
+++ b/src/react.d.ts
@@ -718,6 +718,7 @@ declare module "react" {
                 size?: "small" | "medium" | "large";
                 position?: "top" | "bottom" | "left" | "right";
                 variant?: "default" | "accent";
+                overflow?: "scroll" | "wrap";
             }>;
             "y-tag": El<{
                 color?: string;


### PR DESCRIPTION
### Added

- `y-tabs` gains an `overflow` attribute: `scroll` (default) keeps tabs on a single line and shows prev/next arrow buttons when the strip overflows its container, while `wrap` lets tabs flow onto multiple rows.

### Changed

- `y-code` now scrolls its content within a height-constrained container — set a CSS `height` or `max-height` and the code area scrolls, where previously vertical scrolling only kicked in with `max-lines`.